### PR TITLE
将虚拟环境的安装包导出，导出后发现会出现@file，而不显示具体的版本号的情况

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,66 +1,66 @@
-asttokens==2.0.5
-backcall==0.2.0
-brotlipy==0.7.0
-certifi==2021.10.8
-cffi @ file:///opt/conda/conda-bld/cffi_1642701102775/work
-charset-normalizer @ file:///tmp/build/80754af9/charset-normalizer_1630003229654/work
-cloudpickle==2.0.0
-cryptography @ file:///tmp/build/80754af9/cryptography_1639400846433/work
-cycler==0.11.0
-decorator==5.1.1
-executing==0.8.3
-ffmpeg-python==0.2.0
-fonttools==4.31.2
-future==0.18.2
-gym==0.23.1
-gym-notices==0.0.6
-idna @ file:///tmp/build/80754af9/idna_1637925883363/work
-imageio==2.16.1
-imgaug==0.4.0
-importlib-metadata==4.11.3
-ipython==8.2.0
-jedi==0.18.1
-kiwisolver==1.4.2
-matplotlib==3.5.1
-matplotlib-inline==0.1.3
-mkl-fft==1.3.1
-mkl-random @ file:///tmp/build/80754af9/mkl_random_1626186064646/work
-mkl-service==2.4.0
-networkx==2.7.1
-numpy @ file:///tmp/build/80754af9/numpy_and_numpy_base_1634095647912/work
-opencv-python==4.5.5.64
-packaging==21.3
-pandas==1.4.2
-parso==0.8.3
-pexpect==4.8.0
-pickleshare==0.7.5
-Pillow==9.0.1
-prompt-toolkit==3.0.29
-ptyprocess==0.7.0
-pure-eval==0.2.2
-pycparser @ file:///tmp/build/80754af9/pycparser_1636541352034/work
-Pygments==2.11.2
-pyOpenSSL @ file:///opt/conda/conda-bld/pyopenssl_1643788558760/work
-pyparsing==3.0.7
-PySocks @ file:///tmp/build/80754af9/pysocks_1605305779399/work
-python-dateutil==2.8.2
-pytz==2022.1
-PyWavelets==1.3.0
-requests @ file:///opt/conda/conda-bld/requests_1641824580448/work
-scikit-image==0.19.2
-scipy==1.8.0
-Shapely==1.8.1.post1
-six @ file:///tmp/build/80754af9/six_1644875935023/work
-stack-data==0.2.0
-tifffile==2022.3.25
-timm==0.5.4
-torch==1.11.0
-torchaudio==0.11.0
-torchinfo==1.6.5
-torchvision==0.12.0
-tqdm==4.64.0
-traitlets==5.1.1
-typing_extensions @ file:///opt/conda/conda-bld/typing_extensions_1647553014482/work
-urllib3 @ file:///opt/conda/conda-bld/urllib3_1643638302206/work
-wcwidth==0.2.5
-zipp==3.8.0
+asttokens>=2.0.5
+backcall>=0.2.0
+brotlipy>=0.7.0
+certifi>=2021.10.8
+cffi
+charset-normalizer 
+cloudpickle>=2.0.0
+cryptography
+cycler>=0.11.0
+decorator>=5.1.1
+executing>=0.8.3
+ffmpeg-python>=0.2.0
+fonttools>=4.31.2
+future>=0.18.2
+gym>=0.23.1
+gym-notices>=0.0.6
+idna
+imageio>=2.16.1
+imgaug>=0.4.0
+importlib-metadata>=4.11.3
+ipython>=8.2.0
+jedi>=0.18.1
+kiwisolver>=1.4.2
+matplotlib>=3.5.1
+matplotlib-inline>=0.1.3
+mkl-fft>=1.3.1
+mkl-random 
+mkl-service>=2.4.0
+networkx>=2.7.1
+numpy 
+opencv-python>=4.5.5.64
+packaging>=21.3
+pandas>=1.4.2
+parso>=0.8.3
+pexpect>=4.8.0
+pickleshare>=0.7.5
+Pillow>=9.0.1
+prompt-toolkit>=3.0.29
+ptyprocess>=0.7.0
+pure-eval>=0.2.2
+pycparser 
+Pygments>=2.11.2
+pyOpenSSL 
+pyparsing>=3.0.7
+PySocks 
+python-dateutil>=2.8.2
+pytz>=2022.1
+PyWavelets>=1.3.0
+requests 
+scikit-image>=0.19.2
+scipy>=1.8.0
+Shapely>=1.8.1.post1
+six 
+stack-data>=0.2.0
+tifffile>=2022.3.25
+timm>=0.5.4
+torch>=1.11.0
+torchaudio>=0.11.0
+torchinfo>=1.6.5
+torchvision>=0.12.0
+tqdm>=4.64.0
+traitlets>=5.1.1
+typing_extensions 
+urllib3 
+wcwidth>=0.2.5
+zipp>=3.8.0


### PR DESCRIPTION
原因：
这是 pip 安装软件包的一种特殊语法（自19.1开始受支持）PEP404，
但是该种路径取决于环境，file:///URL 仅在本地文件系统上可用，你不能将生成的 requirements.txt 文件在另一台电脑上使用。

解决方法：
使用如下命令生成requirements.txt

pip list --format=freeze > requirements.txt
此时可以看出已经不含@file了